### PR TITLE
chore: fix Workflow does not contain permissions

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -1,5 +1,8 @@
 name: Secrets scanning
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/yunarch/pdf2image/security/code-scanning/3](https://github.com/yunarch/pdf2image/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since the workflow only performs secret scanning, it likely only requires `contents: read` permissions. This will restrict the `GITHUB_TOKEN` to the minimum necessary permissions, reducing the risk of unintended actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
