### PR TITLE
chore: fix Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   CI: true
   DO_NOT_TRACK: 1


### PR DESCRIPTION
Potential fix for [https://github.com/yunarch/pdf2image/security/code-scanning/2](https://github.com/yunarch/pdf2image/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only performs code linting and does not require write access, we will set `contents: read` as the minimal permission. This ensures that the `GITHUB_TOKEN` has only the necessary permissions to access the repository contents for the linting process.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
